### PR TITLE
these shouldn't become classes automatically

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ colors.translate = function ( flatData, callback )
     flatData.fonts.forEach( function ( font )
     {
         var cls = new colors.lessModel();
-        cls.name = "." + colors.slugify( font.path );
+        cls.name = "." + colors.slugify( font.path ) + "()";
         doc.children.push( cls );
 
         var family = new colors.lessModel();

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ describe( "TrueColors", function ()
 
     it( "should process a file", function ( done )
     {
-        var fontString = ".full-med-text {\n"
+        var fontString = ".full-med-text() {\n"
             + "\tfont-family: Cantarell-Regular;\n"
             + "\tfont-size: @global-font-lg;\n"
             + "\tcolor: @white;\n"
@@ -30,7 +30,7 @@ describe( "TrueColors", function ()
         colors.translatePath( assetPath, function ( err, result )
         {
             assert.equal( err, null );
-            assert.equal( result.indexOf( ".user-cards-geoteriary-text {" ) !== -1, true );
+            assert.equal( result.indexOf( ".user-cards-geoteriary-text() {" ) !== -1, true );
             assert.equal( result.indexOf( "@framework: #1898F6;" ) !== -1, true  );
             assert.equal( result.indexOf( "@global-font-reg: 14px;" ) !== -1, true  );
             assert.equal( result.indexOf( fontString ) !== -1, true  );


### PR DESCRIPTION
@Tathanen of course the class named `error` immediately conflicted with a library, so this should cut down conflicts to only existing LESS with the same name, which isn't going to conflict nearly as often.
